### PR TITLE
Initial IPv6 support

### DIFF
--- a/pkg/wgembed/iface.go
+++ b/pkg/wgembed/iface.go
@@ -11,6 +11,7 @@ package wgembed
 
 import (
 	"net"
+	"strings"
 
 	"github.com/pkg/errors"
 	"golang.zx2c4.com/wireguard/device"
@@ -87,8 +88,8 @@ func New(interfaceName string) (WireGuardInterface, error) {
 	return wg, nil
 }
 
-// LoadConfig reads the given wireguard config file
-// and configured the interface
+// LoadConfigFile reads the given wireguard config file
+// and configures the interface
 func (wg *WireGuardInterfaceImpl) LoadConfigFile(path string) error {
 	config, err := ReadConfig(path)
 	if err != nil {
@@ -97,6 +98,8 @@ func (wg *WireGuardInterfaceImpl) LoadConfigFile(path string) error {
 	return wg.LoadConfig(config)
 }
 
+// LoadConfig takes the given wireguard config object
+// and configures the interface
 func (wg *WireGuardInterfaceImpl) LoadConfig(config *ConfigFile) error {
 	c, err := config.Config()
 	if err != nil {
@@ -109,8 +112,11 @@ func (wg *WireGuardInterfaceImpl) LoadConfig(config *ConfigFile) error {
 		return errors.Wrap(err, "failed to configure wireguard")
 	}
 
-	if err := wg.setIP(config.Interface.Address); err != nil {
-		return errors.Wrap(err, "failed to set interface ip address")
+	addresses := strings.Split(config.Interface.Address, ",")
+	for _, addr := range addresses {
+		if err := wg.setIP(strings.TrimSpace(addr)); err != nil {
+			return errors.Wrap(err, "failed to set interface ip address")
+		}
 	}
 
 	if err := wg.Up(); err != nil {


### PR DESCRIPTION
See https://github.com/freifunkMUC/wg-access-server/pull/1

Some adjustments to allow the Wireguard interface and peers to have multiple IP addresses (i.e. one IPv4 and one IPv6).

Right now done rather ugly by splitting strings, preferably this should be moved into `wg-access-server` and wg-embed should take arrays/slices of strings instead, but for now I didn't want to break the interface.