### PR TITLE
IPv6 cleanup

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,11 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a h1:84IpUNXj4mCR9CuCEvSiCArMbzr/TMbuPIadKDwypkI=
 github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=
 github.com/jsimonetti/rtnetlink v0.0.0-20200117123717-f846d4f6c1f4 h1:nwOc1YaOrYJ37sEBrtWZrdqzK22hiJs3GpDmP3sR2Yw=
 github.com/jsimonetti/rtnetlink v0.0.0-20200117123717-f846d4f6c1f4/go.mod h1:WGuG/smIU4J/54PblvSbh+xvCZmpJnFgr3ds6Z55XMQ=
@@ -18,7 +16,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/mdlayher/genetlink v1.0.0 h1:OoHN1OdyEIkScEmRgxLEe2M9U8ClMytqA5niynLtfj0=
 github.com/mdlayher/genetlink v1.0.0/go.mod h1:0rJ0h4itni50A86M2kHcgS85ttZazNt7a8H2a2cw0Gc=
 github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
-github.com/mdlayher/netlink v1.0.0 h1:vySPY5Oxnn/8lxAPn2cK6kAzcZzYJl3KriSLO46OT18=
 github.com/mdlayher/netlink v1.0.0/go.mod h1:KxeJAFOFLG6AjpyDkQ/iIhxygIUKD+vcwqcnu43w/+M=
 github.com/mdlayher/netlink v1.1.0 h1:mpdLgm+brq10nI9zM1BpX1kpDbh3NLl3RSnVq6ZSkfg=
 github.com/mdlayher/netlink v1.1.0/go.mod h1:H4WCitaheIsdF9yOYu8CFmCgQthAPIWZmcKp9uZHgmY=
@@ -38,7 +35,6 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
-github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe h1:mjAZxE1nh8yvuwhGHpdDqdhtNu2dgbpk93TwoXuk5so=
 github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
@@ -72,7 +68,6 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/pkg/wgembed/config.go
+++ b/pkg/wgembed/config.go
@@ -19,7 +19,7 @@ type ConfigFile struct {
 
 type IfaceConfig struct {
 	PrivateKey string
-	Address    string
+	Address    []string
 	ListenPort *int
 	DNS        []string
 }

--- a/pkg/wgembed/config_test.go
+++ b/pkg/wgembed/config_test.go
@@ -1,0 +1,77 @@
+package wgembed
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReadConfig(t *testing.T) {
+	type args struct {
+		path string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *ConfigFile
+		wantErr bool
+	}{
+		{
+			"dual-stack config file",
+			args{"testdata/dualstack.conf"},
+			&ConfigFile{
+				Interface: IfaceConfig{
+					PrivateKey: "wPNV/LaCgF5yx7bAotuxaaQ6jxsy1H7zs8LuNYzOXHQ=",
+					Address:    []string{"10.44.0.1/24", "fd48:4c4:7aa9::1/64"},
+					DNS:        []string{},
+				},
+				Peers:    []PeerConfig{{PublicKey: "gysKSkCS/VeAyHIAVtf8B/sbQnEd5FYogtj7kO4d4zY=", AllowedIPs: []string{"10.44.0.2/32", "fd48:4c4:7aa9::2/128"}}},
+				wgconfig: nil,
+			},
+			false,
+		},
+		{
+			"IPv4-only config file",
+			args{"testdata/ipv4-only.conf"},
+			&ConfigFile{
+				Interface: IfaceConfig{
+					PrivateKey: "wPNV/LaCgF5yx7bAotuxaaQ6jxsy1H7zs8LuNYzOXHQ=",
+					Address:    []string{"10.44.0.1/24"},
+					DNS:        []string{},
+				},
+				Peers:    []PeerConfig{{PublicKey: "gysKSkCS/VeAyHIAVtf8B/sbQnEd5FYogtj7kO4d4zY=", AllowedIPs: []string{"10.44.0.2/32"}}},
+				wgconfig: nil,
+			},
+			false,
+		},
+		{
+			"IPv6-only config file",
+			args{"testdata/ipv6-only.conf"},
+			&ConfigFile{
+				Interface: IfaceConfig{
+					PrivateKey: "wPNV/LaCgF5yx7bAotuxaaQ6jxsy1H7zs8LuNYzOXHQ=",
+					Address:    []string{"fd48:4c4:7aa9::1/64"},
+					DNS:        []string{},
+				},
+				Peers:    []PeerConfig{{PublicKey: "gysKSkCS/VeAyHIAVtf8B/sbQnEd5FYogtj7kO4d4zY=", AllowedIPs: []string{"fd48:4c4:7aa9::2/128"}}},
+				wgconfig: nil,
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.want.load(); err != nil {
+				t.Errorf("wanted ConfigFile not valid")
+			}
+
+			got, err := ReadConfig(tt.args.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReadConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Error("ReadConfig() result does not match wanted config")
+			}
+		})
+	}
+}

--- a/pkg/wgembed/iface.go
+++ b/pkg/wgembed/iface.go
@@ -11,7 +11,6 @@ package wgembed
 
 import (
 	"net"
-	"strings"
 
 	"github.com/pkg/errors"
 	"golang.zx2c4.com/wireguard/device"
@@ -23,7 +22,7 @@ import (
 
 type WireGuardInterface interface {
 	LoadConfig(config *ConfigFile) error
-	AddPeer(publicKey string, addressCIDR string) error
+	AddPeer(publicKey string, addressCIDR []string) error
 	ListPeers() ([]wgtypes.Peer, error)
 	RemovePeer(publicKey string) error
 	PublicKey() (string, error)
@@ -112,9 +111,8 @@ func (wg *WireGuardInterfaceImpl) LoadConfig(config *ConfigFile) error {
 		return errors.Wrap(err, "failed to configure wireguard")
 	}
 
-	addresses := strings.Split(config.Interface.Address, ",")
-	for _, addr := range addresses {
-		if err := wg.setIP(strings.TrimSpace(addr)); err != nil {
+	for _, addr := range config.Interface.Address {
+		if err := wg.setIP(addr); err != nil {
 			return errors.Wrap(err, "failed to set interface ip address")
 		}
 	}

--- a/pkg/wgembed/management.go
+++ b/pkg/wgembed/management.go
@@ -3,23 +3,24 @@ package wgembed
 import (
 	"fmt"
 	"net"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
-func (wg *WireGuardInterfaceImpl) AddPeer(publicKey string, addressCIDR string) error {
+// AddPeer adds a new peer to the interface.
+// The subnet sizes in addressCIDR should be /32 for IPv4 and /128 for IPv6,
+// as the whole subnet will be added to AllowedIPs for this device.
+func (wg *WireGuardInterfaceImpl) AddPeer(publicKey string, addressCIDR []string) error {
 	key, err := wgtypes.ParseKey(publicKey)
 	if err != nil {
 		return errors.Wrapf(err, "bad public key %v", publicKey)
 	}
 
-	addresses := strings.Split(addressCIDR, ",")
-	parsedAddresses := make([]net.IPNet, 0, len(addresses))
-	for _, addr := range addresses {
-		_, allowedIPs, err := net.ParseCIDR(strings.TrimSpace(addr))
+	parsedAddresses := make([]net.IPNet, 0, len(addressCIDR))
+	for _, addr := range addressCIDR {
+		_, allowedIPs, err := net.ParseCIDR(addr)
 		if err != nil || allowedIPs == nil {
 			return errors.Wrap(err, "bad CIDR value for AllowedIPs")
 		}

--- a/pkg/wgembed/noop.go
+++ b/pkg/wgembed/noop.go
@@ -13,7 +13,7 @@ func (wg *NoOpWireguardInterface) LoadConfig(config *ConfigFile) error {
 	return nil
 }
 
-func (wg *NoOpWireguardInterface) AddPeer(publicKey string, addressCIDR string) error {
+func (wg *NoOpWireguardInterface) AddPeer(publicKey string, addressCIDR []string) error {
 	return nil
 }
 

--- a/pkg/wgembed/testdata/dualstack.conf
+++ b/pkg/wgembed/testdata/dualstack.conf
@@ -1,0 +1,7 @@
+[Interface]
+PrivateKey = wPNV/LaCgF5yx7bAotuxaaQ6jxsy1H7zs8LuNYzOXHQ=
+Address = 10.44.0.1/24, fd48:4c4:7aa9::1/64
+
+[Peer]
+PublicKey = gysKSkCS/VeAyHIAVtf8B/sbQnEd5FYogtj7kO4d4zY=
+AllowedIPs = 10.44.0.2/32, fd48:4c4:7aa9::2/128

--- a/pkg/wgembed/testdata/ipv4-only.conf
+++ b/pkg/wgembed/testdata/ipv4-only.conf
@@ -1,0 +1,7 @@
+[Interface]
+PrivateKey = wPNV/LaCgF5yx7bAotuxaaQ6jxsy1H7zs8LuNYzOXHQ=
+Address = 10.44.0.1/24
+
+[Peer]
+PublicKey = gysKSkCS/VeAyHIAVtf8B/sbQnEd5FYogtj7kO4d4zY=
+AllowedIPs = 10.44.0.2/32

--- a/pkg/wgembed/testdata/ipv6-only.conf
+++ b/pkg/wgembed/testdata/ipv6-only.conf
@@ -1,0 +1,7 @@
+[Interface]
+PrivateKey = wPNV/LaCgF5yx7bAotuxaaQ6jxsy1H7zs8LuNYzOXHQ=
+Address = fd48:4c4:7aa9::1/64
+
+[Peer]
+PublicKey = gysKSkCS/VeAyHIAVtf8B/sbQnEd5FYogtj7kO4d4zY=
+AllowedIPs = fd48:4c4:7aa9::2/128


### PR DESCRIPTION
This contains changes that are already part of my `feature/ip6-support` branch targeting upstream (https://github.com/Place1/wg-embed/pull/1), but haven't been merged to ffmuc's fork yet.

See https://github.com/freifunkMUC/wg-access-server/pull/27

## Changes
* Take a slice of strings for `IfaceConfig.Address`, instead of doing ugly string-splitting
* Take a slice of strings in `WireGuardInterface.AddPeer()` for `addressCIDR`, instead of doing ugly string-splitting
* Add test data config files, add a bunch of sanity-check unit tests for the config parsing.