### PR TITLE
Rename module to github.com/freifunkMUC/wg-embed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/place1/wg-embed
+module github.com/freifunkMUC/wg-embed
 
 go 1.17
 


### PR DESCRIPTION
This will allow us to remove the `replace` directive in wg-access-server's go.mod and reference it directly.
See https://github.com/freifunkMUC/wg-access-server/pull/120