### PR TITLE
Support WG kernel module implementation if available 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2019 James Batt
+Copyright (c) 2021-2022 Freie Netze München e. V.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# wg-embed: an embeddable WireGuard-Go client
+
+This module allows you to embed a WireGuard client into your Go application for easy tunnel setup.
+
+Uses the Go userspace implementation of WireGuard by default, and optionally the Linux kernel module if available.
+
+Supported OSes:
+  - Linux

--- a/pkg/wgembed/iface_darwin.go
+++ b/pkg/wgembed/iface_darwin.go
@@ -3,13 +3,20 @@
 
 package wgembed
 
-import "log"
+import (
+	"github.com/sirupsen/logrus"
+)
 
-func (wg *WireGuardInterfaceImpl) Up() error {
-	log.Println("wg.Up() is a no-op on macos")
+func NewWithOpts(opts Options) (WireGuardInterface, error) {
+	logrus.Debug("creating new userspace wireguard-go interface")
+	return newUserspaceInterface(opts.InterfaceName)
+}
+
+func (wg *commonInterface) Up() error {
+	logrus.Println("wg.Up() is a no-op on macos")
 	return nil
 }
 
-func (wg *WireGuardInterfaceImpl) setIP(ip string) error {
+func (wg *commonInterface) setIP(ip string) error {
 	return nil
 }

--- a/pkg/wgembed/iface_kernel_linux.go
+++ b/pkg/wgembed/iface_kernel_linux.go
@@ -1,0 +1,78 @@
+//go:build linux
+// +build linux
+
+package wgembed
+
+import (
+	"github.com/pkg/errors"
+	"github.com/vishvananda/netlink"
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/wgctrl"
+)
+
+type kernelInterface struct {
+	commonInterface
+}
+
+type netlinkWireguard struct {
+	netlink.LinkAttrs
+}
+
+func newKernelInterface(interfaceName string) (WireGuardInterface, error) {
+	attrs := netlink.NewLinkAttrs()
+	attrs.Name = interfaceName
+	attrs.MTU = device.DefaultMTU
+	link := &netlinkWireguard{attrs}
+
+	err := netlink.LinkAdd(link)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create wireguard kernel device")
+	}
+
+	client, err := wgctrl.New()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create wg client")
+	}
+
+	wg := &kernelInterface{
+		commonInterface: commonInterface{
+			client: client,
+			name:   interfaceName,
+		},
+	}
+
+	return wg, nil
+}
+
+// Close will stop and clean up both the wireguard
+// interface and userspace configuration api
+func (wg *kernelInterface) Close() error {
+	link, err := netlink.LinkByName(wg.Name())
+	if err != nil {
+		return err
+	}
+	var firstErr error
+
+	err = netlink.LinkSetDown(link)
+	if err != nil {
+		firstErr = err
+		// Keep trying
+	}
+	err = netlink.LinkDel(link)
+	if err != nil && firstErr == nil {
+		firstErr = err
+	}
+	err = wg.client.Close()
+	if err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
+
+func (wglink *netlinkWireguard) Attrs() *netlink.LinkAttrs {
+	return &wglink.LinkAttrs
+}
+
+func (wglink *netlinkWireguard) Type() string {
+	return "wireguard"
+}

--- a/pkg/wgembed/iface_userspace.go
+++ b/pkg/wgembed/iface_userspace.go
@@ -1,0 +1,97 @@
+//go:build !windows
+// +build !windows
+
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2019 WireGuard LLC. All Rights Reserved.
+ */
+
+// modified from https://git.zx2c4.com/wireguard-go
+
+package wgembed
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/pkg/errors"
+	"golang.zx2c4.com/wireguard/conn"
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/ipc"
+	"golang.zx2c4.com/wireguard/tun"
+	"golang.zx2c4.com/wireguard/wgctrl"
+)
+
+// userspaceInterface represents an userspace wireguard-go
+// network interface
+type userspaceInterface struct {
+	commonInterface
+	device *device.Device
+	uapi   net.Listener
+}
+
+func newUserspaceInterface(interfaceName string) (WireGuardInterface, error) {
+	wg := &userspaceInterface{
+		commonInterface: commonInterface{
+			name: interfaceName,
+		},
+	}
+
+	client, err := wgctrl.New()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create wg client")
+	}
+	wg.client = client
+
+	tunDevice, err := tun.CreateTUN(wg.name, device.DefaultMTU)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create TUN device")
+	}
+
+	// open UAPI file (or use supplied fd)
+	fileUAPI, err := ipc.UAPIOpen(wg.name)
+	if err != nil {
+		return nil, errors.Wrap(err, "UAPI listen error")
+	}
+
+	logger := device.NewLogger(device.LogLevelError, fmt.Sprintf("(%s) ", interfaceName))
+	wg.device = device.NewDevice(tunDevice, conn.NewDefaultBind(), logger)
+
+	errs := make(chan error)
+
+	uapi, err := ipc.UAPIListen(wg.name, fileUAPI)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to listen on uapi socket")
+	}
+	wg.uapi = uapi
+
+	go func() {
+		for {
+			connection, err := uapi.Accept()
+			if err != nil {
+				errs <- err
+				return
+			}
+			go wg.device.IpcHandle(connection)
+		}
+	}()
+
+	return wg, nil
+}
+
+// Wait will return a channel that signals when the
+// wireguard interface is stopped
+func (wg *userspaceInterface) Wait() chan struct{} {
+	return wg.device.Wait()
+}
+
+// Close will stop and clean up both the wireguard
+// interface and userspace configuration api
+func (wg *userspaceInterface) Close() error {
+	if err := wg.uapi.Close(); err != nil {
+		return err
+	}
+	wg.device.Close()
+	wg.client.Close()
+	return nil
+}

--- a/pkg/wgembed/iface_windows.go
+++ b/pkg/wgembed/iface_windows.go
@@ -3,13 +3,48 @@
 
 package wgembed
 
-import "log"
+import (
+	"net"
 
-func (wg *WireGuardInterfaceImpl) Up() error {
-	log.Println("wg.Up() is a no-op on windows")
+	"github.com/sirupsen/logrus"
+	"golang.zx2c4.com/wireguard/device"
+)
+
+// userspaceInterface represents an userspace wireguard-go
+// network interface
+type userspaceInterface struct {
+	commonInterface
+	device *device.Device
+	uapi   net.Listener
+}
+
+func NewWithOpts(opts Options) (WireGuardInterface, error) {
+	logrus.Debug("creating new userspace wireguard-go interface")
+	return newUserspaceInterface(opts.InterfaceName)
+}
+
+func newUserspaceInterface(interfaceName string) (WireGuardInterface, error) {
+	// TODO: https://git.zx2c4.com/wireguard-go/tree/main_windows.go
+	logrus.Println("newUserspaceInterface not implemented for Windows")
+	return &userspaceInterface{}, nil
+}
+
+func (wg *commonInterface) Up() error {
+	logrus.Println("wg.Up() is a no-op on windows")
 	return nil
 }
 
-func (wg *WireGuardInterfaceImpl) setIP(ip string) error {
+func (wg *commonInterface) setIP(ip string) error {
+	return nil
+}
+
+// Close will stop and clean up both the wireguard
+// interface and userspace configuration api
+func (wg *userspaceInterface) Close() error {
+	if err := wg.uapi.Close(); err != nil {
+		return err
+	}
+	wg.device.Close()
+	wg.client.Close()
 	return nil
 }

--- a/pkg/wgembed/management.go
+++ b/pkg/wgembed/management.go
@@ -12,7 +12,7 @@ import (
 // AddPeer adds a new peer to the interface.
 // The subnet sizes in addressCIDR should be /32 for IPv4 and /128 for IPv6,
 // as the whole subnet will be added to AllowedIPs for this device.
-func (wg *WireGuardInterfaceImpl) AddPeer(publicKey string, addressCIDR []string) error {
+func (wg *commonInterface) AddPeer(publicKey string, addressCIDR []string) error {
 	key, err := wgtypes.ParseKey(publicKey)
 	if err != nil {
 		return errors.Wrapf(err, "bad public key %v", publicKey)
@@ -40,7 +40,7 @@ func (wg *WireGuardInterfaceImpl) AddPeer(publicKey string, addressCIDR []string
 	})
 }
 
-func (wg *WireGuardInterfaceImpl) ListPeers() ([]wgtypes.Peer, error) {
+func (wg *commonInterface) ListPeers() ([]wgtypes.Peer, error) {
 	device, err := wg.Device()
 	if err != nil {
 		return nil, err
@@ -48,7 +48,7 @@ func (wg *WireGuardInterfaceImpl) ListPeers() ([]wgtypes.Peer, error) {
 	return device.Peers, nil
 }
 
-func (wg *WireGuardInterfaceImpl) RemovePeer(publicKey string) error {
+func (wg *commonInterface) RemovePeer(publicKey string) error {
 	key, err := wgtypes.ParseKey(publicKey)
 	if err != nil {
 		return errors.Wrap(err, "bad public key")
@@ -65,7 +65,7 @@ func (wg *WireGuardInterfaceImpl) RemovePeer(publicKey string) error {
 	})
 }
 
-func (wg *WireGuardInterfaceImpl) HasPeer(publicKey string) bool {
+func (wg *commonInterface) HasPeer(publicKey string) bool {
 	peers, err := wg.ListPeers()
 	if err != nil {
 		logrus.Error(errors.Wrap(err, "failed to list peers"))
@@ -79,7 +79,7 @@ func (wg *WireGuardInterfaceImpl) HasPeer(publicKey string) bool {
 	return false
 }
 
-func (wg *WireGuardInterfaceImpl) Peer(publicKey string) (*wgtypes.Peer, error) {
+func (wg *commonInterface) Peer(publicKey string) (*wgtypes.Peer, error) {
 	peers, err := wg.ListPeers()
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func (wg *WireGuardInterfaceImpl) Peer(publicKey string) (*wgtypes.Peer, error) 
 }
 
 // PublicKey returns the currently configured wireguard public key
-func (wg *WireGuardInterfaceImpl) PublicKey() (string, error) {
+func (wg *commonInterface) PublicKey() (string, error) {
 	device, err := wg.Device()
 	if err != nil {
 		return "", err
@@ -101,7 +101,7 @@ func (wg *WireGuardInterfaceImpl) PublicKey() (string, error) {
 	return device.PublicKey.String(), nil
 }
 
-func (wg *WireGuardInterfaceImpl) Port() (int, error) {
+func (wg *commonInterface) Port() (int, error) {
 	device, err := wg.Device()
 	if err != nil {
 		return 0, err
@@ -109,7 +109,7 @@ func (wg *WireGuardInterfaceImpl) Port() (int, error) {
 	return device.ListenPort, nil
 }
 
-func (wg *WireGuardInterfaceImpl) configure(cb func(*wgtypes.Config) error) error {
+func (wg *commonInterface) configure(cb func(*wgtypes.Config) error) error {
 	// TODO: concurrency
 	// s.lock.Lock()
 	// defer s.lock.Unlock()


### PR DESCRIPTION
## Motivation

The kernel module of WireGuard promises more performance, less latency and less CPU load, mostly because packets don't need to be copied between kernel and userspace and less context switches.
It is also _much_ easier to set up code-wise (a single call with the netlink library!)

I've planned for this for some time now, and since this package already uses the wgctrl library which can handle all official-ish implementations out there, it's quite easy to do.

## Changes

The diff looks worse than it is, it's mostly moving things around to have a logical split between the userspace and kernel handling code.
Basically the old `New()` function which has all the userspace business logic has moved to `newUserspaceInterface()` in `iface_userspace`.
The new things are:
  - `newKernelInterface()` with comes down to a single `netlink` call to create the interface
  - `kernelInterface.Close()` which downs and removes the interface
  - A `NewWithOpts()` function which replaces the `New()` function and allows callers to enable the kernel module.
    Falls back to userspace if kernel throws any error.

The remaining functionality (`Up()`, `LoadConfig()`, ...) can be reused from the userspace implementation code thanks to the abstractions of wgctrl.

Testing showed netlink loads the kernel module automatically, even inside a Docker container as long as it has `CAP_NET_ADMIN`, doesn't even require a `/lib/modules` and mount.

I've also added a basic README and a explicit LICENSE file (there was already a MIT SPDX license header)