### PR TITLE
allow setting the MTU on an interface

### DIFF
--- a/pkg/wgembed/config.go
+++ b/pkg/wgembed/config.go
@@ -22,6 +22,7 @@ type IfaceConfig struct {
 	Address    []string
 	ListenPort *int
 	DNS        []string
+	MTU        *int
 }
 
 type PeerConfig struct {

--- a/pkg/wgembed/iface_linux.go
+++ b/pkg/wgembed/iface_linux.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	"golang.zx2c4.com/wireguard/device"
 )
 
 // NewWithOpts creates a new network interface, needs to be enabled with WireGuardInterface.Up() afterwards.
@@ -36,7 +37,11 @@ func (wg *commonInterface) Up() error {
 		return errors.Wrap(err, "failed to bring wireguard interface up")
 	}
 
-	if err := netlink.LinkSetMTU(link, 1420); err != nil {
+	MTU := device.DefaultMTU
+	if wg.config.Interface.MTU != nil {
+		MTU = *wg.config.Interface.MTU
+	}
+	if err := netlink.LinkSetMTU(link, MTU); err != nil {
 		return errors.Wrap(err, "failed to set wireguard mtu")
 	}
 


### PR DESCRIPTION
This is a follow up of https://github.com/freifunkMUC/wg-access-server/pull/401 to incoporate the MTU into the interface on the server-side.